### PR TITLE
Fix/ciatph 18

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'linebreak-style': ['error', 'unix'],
     'quotes': ['error', 'single'],
     'semi': ['error', 'never'],
+    // 'no-console': ['error', { 'allow': ['error'] }]
     // 'no-unused-vars': 'off',
     // 'no-undef': 'off'
   }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@
 
 It uses `/data/day1.xlsx` (downloaded and stored as of this 20220808) from PAGASA's [10-day weather forecast excel files](https://www.pagasa.dost.gov.ph/climate/climate-prediction/10-day-climate-forecast) as the data source.
 
+Extracted municipalities are written in JSON files following the format:
+
+```
+{
+    "metadata": {
+        "source": "https://pubfiles.pagasa.dost.gov.ph/pagasaweb/files/climate/tendayweatheroutlook/day1.xlsx",
+        "title": "List of PH Municipalities By Province and Region",
+        "description": "This dataset generated with reference to the excel file contents from the source URL on 20220808.",
+        "date_created": "Mon Aug 08 2022"
+    },
+    "data": {
+        "Albay": ["Bacacay", "Camalig", ... ],
+        "Camarines Norte": ["Basud", "Capalonga", ... ],
+        "Camarines Sur": ["Baao", "Balatan", ... ],
+         ...
+    }
+}
+```
+
 ## Requirements
 
 The following dependencies are used for this project. Feel free to use other dependency versions as needed.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.18.10/xlsx-0.18.10.tgz"
   },
   "pkg": {
-    "assets": ["data/*"],
+    "assets": ["data/*", ".env*"],
     "targets": ["node16-win-x64"],
     "outputPath": "./dist"
   }

--- a/src/classes/excel/excel.js
+++ b/src/classes/excel/excel.js
@@ -260,7 +260,7 @@ class ExcelFile {
       const municipalities = this.listMunicipalities({ provinces })
       const str = {
         metadata: {
-          source: process.env.EXCEL_FILE_URL,
+          source: process.env.EXCEL_FILE_URL || '',
           title: 'List of PH Municipalities By Province and Region',
           description: 'This dataset generated with reference to the excel file contents from the source URL.',
           date_created: new Date().toDateString()

--- a/src/lib/ph_excelfile.js
+++ b/src/lib/ph_excelfile.js
@@ -1,12 +1,16 @@
-require('dotenv').config()
 const path = require('path')
+require('dotenv').config({
+  // Set the dotenv path when packaging with pkg
+  path: path.join(__dirname, '..', '..', '.env')
+})
+
 const { ExcelFile } = require('../classes/excel')
 
 const PHExcel = new ExcelFile({
   // When pkg encounters path.join(__dirname, '../path/to/asset'),
   // it automatically packages the file specified as an asset.
-  pathToFile: path.join(__dirname, '..', '..', 'data', 'day1.xlsx'),
-  url: process.env.EXCEL_FILE_URL
+  pathToFile: path.join(__dirname, '..', '..', 'data', 'day1.xlsx')
+  // url: process.env.EXCEL_FILE_URL
 })
 
 PHExcel.init()


### PR DESCRIPTION
- This is a fix for Issue #18 
- Configured `dotenv` to use absolute file paths instead of just `require('dotenv').config()`
   ```
   require('dotenv').config({
     // Set the dotenv path when packaging with pkg
     path: path.join(__dirname, '..', '..', '.env')
   })
   ```
- Included the `.env` file in **pkg**'s `assets` entry in package.json:
   ```
   "pkg": {
       "assets": ["data/*", ".env*"],
         ...
   }
   ``` 