### PR TITLE
Fix/ciatph 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Packge and archive the executable files
         run: |
           npm run build:win:all
+          cd dist
+          dir
 
       - name: Archive Development Artifact
         uses: actions/upload-artifact@v3

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "list:province": "node src/scripts/by_province.js",
     "list:region": "node src/scripts/by_region.js",
     "example": "node src/scripts/sample_usage.js",
-    "build:win:region": "npx pkg ./src/scripts/by_region.js -c package.json --compress GZip -o ./dist/ph-regions",
-    "build:win:province": "npx pkg ./src/scripts/by_province.js -c package.json --compress GZip -o ./dist/ph-provinces",
+    "build:win:region": "npx pkg ./src/scripts/by_region.js -c package.json --compress GZip -o ./dist/ph-regions-win",
+    "build:win:province": "npx pkg ./src/scripts/by_province.js -c package.json --compress GZip -o ./dist/ph-provinces-win",
     "build:win:all": "npm run build:win:region && npm run build:win:province",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix"


### PR DESCRIPTION
- Fix the mismatching windows executable filenames with those written in the release.yml
- Rename the build executable files to `ph-regions-win.exe` and `ph-provinces-win.exe` 