### PR TITLE
v1.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,10 @@ jobs:
 
       - name: Prepare App
         run: |
-          mv dist/ph-provinces-win.exe dist/ph-provinces-win_${{github.ref_name}}.exe
-          mv dist/ph-regions-win.exe dist/ph-regions-win_${{github.ref_name}}.exe
-          tar cvfz ph-regions-win_${{github.ref_name}}.tar.gz dist/ph-regions-win_${{github.ref_name}}.exe
-          tar cvfz ph-provinces-win_${{github.ref_name}}.tar.gz dist/ph-provinces-win_${{github.ref_name}}.exe
+          mv ph-provinces-win.exe ph-provinces-win_${{github.ref_name}}.exe
+          mv ph-regions-win.exe ph-regions-win_${{github.ref_name}}.exe
+          tar cvfz ph-regions-win_${{github.ref_name}}.tar.gz ph-regions-win_${{github.ref_name}}.exe
+          tar cvfz ph-provinces-win_${{github.ref_name}}.tar.gz ph-provinces-win_${{github.ref_name}}.exe
           ls -l -a
       - name: Attach Artifact to Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Packge and archive the executable files
         run: |
           npm run build:win:all
+          cd dist
+          dir
 
       - name: Archive Development Artifact
         uses: actions/upload-artifact@v3

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "list:province": "node src/scripts/by_province.js",
     "list:region": "node src/scripts/by_region.js",
     "example": "node src/scripts/sample_usage.js",
-    "build:win:region": "npx pkg ./src/scripts/by_region.js -c package.json --compress GZip -o ./dist/ph-regions",
-    "build:win:province": "npx pkg ./src/scripts/by_province.js -c package.json --compress GZip -o ./dist/ph-provinces",
+    "build:win:region": "npx pkg ./src/scripts/by_region.js -c package.json --compress GZip -o ./dist/ph-regions-win",
+    "build:win:province": "npx pkg ./src/scripts/by_province.js -c package.json --compress GZip -o ./dist/ph-provinces-win",
     "build:win:all": "npm run build:win:region && npm run build:win:province",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix"


### PR DESCRIPTION
- Follow-up fixes for the release workflows errors on [v1.0.2a](https://github.com/ciatph/ph-municipalities/pull/24), [v1.0.2b](https://github.com/ciatph/ph-municipalities/pull/25) and [v1.0.2c](https://github.com/ciatph/ph-municipalities/pull/27)
- Comment-out the `linebreak-style': ['error', 'unix']` eslint rules when linting on a windows-based GitHub Actions hosted runner
- Fix the mismatching windows executable filenames with those written in the release.yml
- Rename the build executable files to `ph-regions-win.exe` and `ph-provinces-win.exe` 
- Remove the `dist` directory prefix on the Download Artifact step.