### PR TITLE
Fix/ciatph 18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Packge and archive the executable files
         run: |
+          cp .env.example .env
           npm run build:win:all
           cd dist
           dir


### PR DESCRIPTION
This is an update for Issue #18.
Create a `.env` file during the windows binaries packaging stage on GitHub Actions.