### PR TITLE
Fix/ciatph 32

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 EXCEL_FILE_URL=https://pubfiles.pagasa.dost.gov.ph/pagasaweb/files/climate/tendayweatheroutlook/day1.xlsx
+DEFAULT_EXCEL_FILE_URL=https://pubfiles.pagasa.dost.gov.ph/pagasaweb/files/climate/tendayweatheroutlook/day1.xlsx
 SHEETJS_COLUMN=__EMPTY
 SORT_ALPHABETICAL=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-npm:
+    name: Publish to NPM registry
     runs-on: ubuntu-latest
     needs: build-on-win
     steps:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ The following dependencies are used for this project. Feel free to use other dep
 - Displays a list of available PH **region** names.
 - Lists all provinces and municipalities of a specified region via commandline input.
 - Asks for an option to write results to a JSON file.
+- Run the script as follows if installed using `npm i ph-municipalities`:
+   - `node .\node_modules\ph-municipalities\src\scripts\by_region.js`
 
 ### `npm run list:province`
 
@@ -100,6 +102,8 @@ The following dependencies are used for this project. Feel free to use other dep
   - Loads and parses the downloaded excel file in `/data/datasource.xlsx` if download URL input is provided.
 - Lists all municipalities under specified province(s) via commandline input.
 - Asks for an option to write results to a JSON file.
+- Run the script as follows if installed using `npm i ph-municipalities`:
+   - `node .\node_modules\ph-municipalities\src\scripts\by_province.js`
 
 ### `npm run example`
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The following dependencies are used for this project. Feel free to use other dep
 
 - Asks users to enter the download URL of a remote excel file or use the default local excel file
   - Loads and parses the local excel file in `/data/day1.xlsx` by default.
-  - Loads and parses the downloaded excel file in `/data/datasource.xlsx` if download URL input is provided.
+  - Loads and parses the downloaded excel file in `/data/datasource.xlsx` if download URL in the class constructor is provided.
 - Displays a list of available PH **region** names.
 - Lists all provinces and municipalities of a specified region via commandline input.
 - Asks for an option to write results to a JSON file.
@@ -99,7 +99,7 @@ The following dependencies are used for this project. Feel free to use other dep
 
 - Asks users to enter the download URL of a remote excel file or use the default local excel file
   - Loads and parses the local excel file in `/data/day1.xlsx` by default.
-  - Loads and parses the downloaded excel file in `/data/datasource.xlsx` if download URL input is provided.
+  - Loads and parses the downloaded excel file in `/data/datasource.xlsx` if download URL in the class constructor is provided.
 - Lists all municipalities under specified province(s) via commandline input.
 - Asks for an option to write results to a JSON file.
 - Run the script as follows if installed using `npm i ph-municipalities`:
@@ -186,7 +186,7 @@ file.writeMunicipalities({
    prettify: true
 })
 
-// JSON data of the parsed excel file will be accessible on
+// JSON data of the parsed excel file will is accessible on
 // file.datalist
 console.log(file.datalist)
 ```

--- a/README.md
+++ b/README.md
@@ -176,12 +176,12 @@ file = new ExcelFile({
 
 // listMunicipalities() lists all municipalities
 // for each province
-const municipalitiesFromProvince =
-   file.listMunicipalities(['Albay','Masbate','Sorsogon'])
+const provinces = ['Albay','Masbate','Sorsogon']
+const municipalitiesFromProvince = file.listMunicipalities(provinces)
 
-// writeMunicipalities() writes municipalities data in a JSON file
+// writeMunicipalities() writes municipalities data to a JSON file
 file.writeMunicipalities({
-   provinces: municipalitiesFromProvince,
+   provinces,
    fileName: path.join(__dirname, 'municipalities.json'),
    prettify: true
 })

--- a/data/regions.json
+++ b/data/regions.json
@@ -34,7 +34,7 @@
       "name": "National Capital Region",
       "abbrev": "NCR",
       "region_num": "",
-      "provinces": ["Metro Manila"]
+      "provinces": ["Metropolitan Manila"]
     },
     {
       "name": "Region IV-A",

--- a/src/classes/excel/index.js
+++ b/src/classes/excel/index.js
@@ -253,8 +253,8 @@ class ExcelFile {
   /**
    * Writes queried municipalities data to a JSON file.
    * Lists municipalities by by provinces.
-   * @param {String} provinces - Array of case-sensitive province names. Starts with an upper case.
-   * @param {String} filName - Full file path to a JSON file
+   * @param {String[]} provinces - Array of case-sensitive province names. Starts with an upper case.
+   * @param {String} fielName - Full file path to a JSON file
    * @param {Bool} prettify - Write the JSON content with proper spacings and newlines
    * @returns
    */

--- a/src/classes/excel/index.js
+++ b/src/classes/excel/index.js
@@ -266,9 +266,12 @@ class ExcelFile {
     try {
       // List the municipalities
       const municipalities = this.listMunicipalities({ provinces })
+
+      const url = (this.#url) ? this.#url : `local datasource cache from ${process.env.DEFAULT_EXCEL_FILE_URL}`
+
       const str = {
         metadata: {
-          source: process.env.EXCEL_FILE_URL || '',
+          source: url || '',
           title: 'List of PH Municipalities By Province and Region',
           description: 'This dataset generated with reference to the excel file contents from the source URL.',
           date_created: new Date().toDateString()

--- a/src/classes/excel/index.js
+++ b/src/classes/excel/index.js
@@ -263,6 +263,10 @@ class ExcelFile {
       throw new Error('Please enter a filename ending in .json')
     }
 
+    if (!/\.(json)$/i.test(fileName)) {
+      throw new Error('Please enter a filename ending in .json')
+    }
+
     try {
       // List the municipalities
       const municipalities = this.listMunicipalities({ provinces })

--- a/src/lib/selector.js
+++ b/src/lib/selector.js
@@ -14,7 +14,7 @@ const selectDataSource = async () => {
   while (!exit) {
     // Prompt to enter the download URL of a remote excel file
     if (url === undefined) {
-      const askDownload = await prompt('\nWould you like to download and use a remote Excel file?\nPress enter to ignore. Press Y and enter to proceed. [n/Y]:')
+      const askDownload = await prompt('\nWould you like to download and use a remote Excel file?\nPress enter to ignore. Press Y and enter to proceed. [n/Y]: ')
 
       if (askDownload === 'Y') {
         const pathToFile = path.join(process.cwd(), 'datasource.xlsx')

--- a/src/scripts/by_province.js
+++ b/src/scripts/by_province.js
@@ -22,28 +22,37 @@ const main = async () => {
       if (provinces) {
         // List the municipalities of a targets province(s)
         const { total, data } = formatDisplay(ExcelHandler.listMunicipalities({ provinces }))
-        console.log(data)
-        console.log(`\nTotal: ${total}`)
+
+        if (total === 0) {
+          await prompt('No municipalities to show.\n')
+        } else {
+          console.log(data)
+          console.log(`\nTotal: ${total}`)
+
+          // Prompt to write results to a JSON file
+          const write = await prompt('\nWrite results to a JSON file?\nPress enter to ignore. Press Y and enter to proceed. [n/Y]: ')
+
+          if (write === 'Y') {
+            const fileName = await prompt('\nEnter the JSON filename: ')
+
+            // Use process.cwd() to enable file paths when building with "pkg"
+            const filePath = path.join(process.cwd(), fileName)
+
+            try {
+              ExcelHandler.writeMunicipalities({
+                provinces,
+                fileName: filePath
+              })
+
+              console.log(`JSON file created in ${filePath}\n`)
+            } catch (err) {
+              console.log(err.message)
+            }
+          }
+        }
       }
 
-      // Prompt to write results to a JSON file
-      const write = await prompt('\nWrite results to a JSON file? [n/Y]: ')
-
-      if (write === 'Y') {
-        const fileName = await prompt('\nEnter the JSON filename: ')
-
-        // Use process.cwd() to enable file paths when building with "pkg"
-        const filePath = path.join(process.cwd(), fileName)
-
-        ExcelHandler.writeMunicipalities({
-          provinces,
-          fileName: filePath
-        })
-
-        console.log(`JSON file created in ${filePath}`)
-      }
-
-      const ex = await prompt('\nExit? (Enter X to exit): ')
+      const ex = await prompt('Exit? (Enter X to exit): ')
       exit = (ex === 'X')
     }
   }

--- a/src/scripts/by_province.js
+++ b/src/scripts/by_province.js
@@ -7,7 +7,7 @@ const selectDataSource = require('../lib/selector')
 // Lists all municipalities under the specified provinces.
 const main = async () => {
   let exit = false
-  let ExcelHandler
+  let ExcelHandler = null
 
   while (!exit) {
     // Prompt to enter the download URL of a remote excel file or use the default local excel file

--- a/src/scripts/by_province.js
+++ b/src/scripts/by_province.js
@@ -48,12 +48,12 @@ const main = async () => {
             } catch (err) {
               console.log(err.message)
             }
+
+            const ex = await prompt('Exit? (Enter X to exit): ')
+            exit = (ex === 'X')
           }
         }
       }
-
-      const ex = await prompt('Exit? (Enter X to exit): ')
-      exit = (ex === 'X')
     }
   }
 

--- a/src/scripts/by_province.js
+++ b/src/scripts/by_province.js
@@ -11,7 +11,9 @@ const main = async () => {
 
   while (!exit) {
     // Prompt to enter the download URL of a remote excel file or use the default local excel file
-    ExcelHandler = await selectDataSource()
+    if (ExcelHandler === null) {
+      ExcelHandler = await selectDataSource()
+    }
 
     if (ExcelHandler !== null) {
       // Prompt to ask for province name(s)

--- a/src/scripts/by_region.js
+++ b/src/scripts/by_region.js
@@ -8,7 +8,7 @@ const regions = require('../../data/regions.json')
 // Lists all municipalities under the provinces of a region.
 const main = async () => {
   let exit = false
-  let ExcelHandler
+  let ExcelHandler = null
 
   while (!exit) {
     // Prompt to enter the download URL of a remote excel file or use the default local excel file

--- a/src/scripts/by_region.js
+++ b/src/scripts/by_region.js
@@ -12,7 +12,9 @@ const main = async () => {
 
   while (!exit) {
     // Prompt to enter the download URL of a remote excel file or use the default local excel file
-    ExcelHandler = await selectDataSource()
+    if (ExcelHandler === null) {
+      ExcelHandler = await selectDataSource()
+    }
 
     if (ExcelHandler !== null) {
       // Display region abbreviations

--- a/src/scripts/by_region.js
+++ b/src/scripts/by_region.js
@@ -9,6 +9,7 @@ const regions = require('../../data/regions.json')
 const main = async () => {
   let exit = false
   let ExcelHandler = null
+  let idx
 
   while (!exit) {
     // Prompt to enter the download URL of a remote excel file or use the default local excel file
@@ -28,10 +29,10 @@ const main = async () => {
 
       if (region) {
         // Check if the region name exists in the masterlist
-        const idx = regions.data.findIndex(item => item.name === region)
+        idx = regions.data.findIndex(item => item.name === region)
 
         if (idx === -1) {
-          console.log('Region name not found.')
+          await prompt('Region name not found.\n')
         } else {
           // List the provinces of a target region
           const provinces = regions.data.find(x => x.name === region).provinces
@@ -50,18 +51,24 @@ const main = async () => {
             // Use process.cwd() to enable file paths when building with "pkg"
             const filePath = path.join(process.cwd(), fileName)
 
-            ExcelHandler.writeMunicipalities({
-              provinces,
-              fileName: filePath
-            })
+            try {
+              ExcelHandler.writeMunicipalities({
+                provinces,
+                fileName: filePath
+              })
 
-            console.log(`JSON file created in ${filePath}`)
+              console.log(`JSON file created in ${filePath}`)
+            } catch (err) {
+              console.log(err.message)
+            }
           }
         }
       }
 
-      const ex = await prompt('\nExit? (Enter X to exit): ')
-      exit = (ex === 'X')
+      if (idx >= 0) {
+        const ex = await prompt('\nExit? (Enter X to exit): ')
+        exit = (ex === 'X')
+      }
     }
   }
 


### PR DESCRIPTION
- Update the `Metro Manila` province name in `/data/regions.json` to `Metropolitan Manila`, [#32](https://github.com/ciatph/ph-municipalities/issues/32)
- Less redundant user prompts
- Ask for the excel file download URL only once
- Write the current download URL or the default local file cache to the output `source` JSON info
- Check for `.json` file extension 