### PR TITLE
Feature/ciatph 53

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,12 @@ const ExcelFile = require('./classes/excel')
 
 // Reads an existing excel file on /data/day1.xlsx
 file = new ExcelFile({
-   pathToFile: path.join(__dirname, 'data', 'day1.xlsx')
+   pathToFile: path.join(__dirname, 'data', 'day1.xlsx'),
+   // fastload: false
 })
+
+// Call init() if fastload=false
+// file.init()
 
 // listMunicipalities() lists all municipalities
 // for each province
@@ -196,6 +200,11 @@ const json2 = file.shapeJsonData(provinces)
 // JSON data of the parsed excel file will is accessible on
 // file.datalist
 console.log(file.datalist)
+
+// Set the contents of file.datalist
+file.datalist = [
+   { municipality: 'Tayum', province: 'Abra' },
+   { municipality: 'Bucay', province: 'Abra' }]
 ```
 
 ### Download and Parse a Remote Excel File

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "municipalities-by-province",
-  "version": "1.0.0",
+  "name": "ph-municipalities",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "municipalities-by-province",
-      "version": "1.0.0",
+      "name": "ph-municipalities",
+      "version": "1.0.8",
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.0.1",
@@ -2129,9 +2129,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -5048,9 +5048,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ph-municipalities",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "List and write the `municipalities` of Philippines provinces or regions into JSON files",
   "main": "index.js",
   "scripts": {

--- a/src/classes/excel/index.js
+++ b/src/classes/excel/index.js
@@ -52,8 +52,10 @@ class ExcelFile {
    *    - Full local file path of an existing excel file, if "url" is not provided
    *    - Full local file path of an excel on where to download the remote excel file from "url",
    *      if the "url" parameter is provided
+   * @param {Bool} fastload - Start loading and parsing the local excel file on class initialization if the "url" param is not provided.
+   *    - If "false", call init() later on a more convenient time
    */
-  constructor ({ url, pathToFile }) {
+  constructor ({ url, pathToFile, fastload = true }) {
     if (url === '' || pathToFile === '') {
       throw new Error('Missing remote file url or local file path.')
     }
@@ -73,7 +75,9 @@ class ExcelFile {
       // Set the remote excel file download URL
       this.#url = url
     } else {
-      this.init()
+      if (fastload) {
+        this.init()
+      }
     }
   }
 
@@ -211,6 +215,11 @@ class ExcelFile {
   // Return the processed Object array (masterlist) of municipality and province names
   get datalist () {
     return this.#datalist
+  }
+
+  // Set the private data list contents
+  set datalist (data) {
+    this.#datalist = data
   }
 
   /**

--- a/src/scripts/sample_usage.js
+++ b/src/scripts/sample_usage.js
@@ -7,6 +7,7 @@ const main = async () => {
   const file = new ExcelFile({
     pathToFile: path.join(__dirname, '..', '..', 'data', 'temp.xlsx'),
     url: process.env.EXCEL_FILE_URL
+    // fastload: false
   })
 
   try {
@@ -30,9 +31,9 @@ const main = async () => {
     let count = 0
     let stats = '\nPROVINCES:\n'
 
-    for (const province in municipalities) {
-      count += municipalities[province].length
-      stats += `${province}: ${municipalities[province].length}, ${municipalities[province].toString()}\n\n`
+    for (const province in municipalities.data) {
+      count += municipalities.data[province].length
+      stats += `${province}: ${municipalities.data[province].length}, ${municipalities.data[province].toString()}\n\n`
     }
 
     console.log(stats)


### PR DESCRIPTION
- Data setter method for class ExcelFile's `this.#datalist` field, [#53](https://github.com/ciatph/ph-municipalities/issues/53)
- `fastload` constructor param to defer loading and parsing a local excel file:
   ```
   const localfile = new ExcelFile({
     pathToFile: path.join(__dirname, 'loadme.xlsx'),
     fastload: false // default is true
   })

   // No need to init() on local files when fastload=true
   localfile.init()
   ``` 