### PR TITLE
Fix/ciatph 67 - municipality names detection

### DIFF
--- a/src/classes/excel/index.js
+++ b/src/classes/excel/index.js
@@ -185,7 +185,7 @@ class ExcelFile {
    * @returns {Bool} true | false
    */
   followsStringPattern (str) {
-    return /[a-zA-z] *\([^)]*\) */.test(str)
+    return /[a-zA-Z,.] *\([^)]*\) */.test(str)
   }
 
   /**


### PR DESCRIPTION
- Detect municipality names ending with a period or comma symbol, [#67](https://github.com/ciatph/ph-municipalities/issues/67) 