### PR TITLE
Fix/ciatph 79

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,6 @@ jobs:
       - name: Publish package
         run: |
           cp README.md app/
-          # Exclude examples
-          rm -r -f /app/examples
           cd app
           npm publish
         env:

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ npm run list:region
 
 - Asks users to enter the download URL of a remote excel file or use the default local excel file
   - Loads and parses the local excel file in `/app/data/day1.xlsx` by default.
-  - Loads and parses the downloaded excel file in `/app/data/datasource.xlsx` if download URL in the class constructor is provided.
+  - Loads and parses the downloaded excel file to `/app/data/datasource.xlsx` if download URL in the class constructor is provided.
 - Displays a list of available PH **region** names.
 - Lists all provinces and municipalities of a specified region via commandline input.
 - Asks for an option to write results to a JSON file.
@@ -162,7 +162,7 @@ npm run list:region
 
 - Asks users to enter the download URL of a remote excel file or use the default local excel file
   - Loads and parses the local excel file in `/app/data/day1.xlsx` by default.
-  - Loads and parses the downloaded excel file in `/app/data/datasource.xlsx` if download URL in the class constructor is provided.
+  - Loads and parses the downloaded excel file to `/app/data/datasource.xlsx` if download URL in the class constructor is provided.
 - Lists all municipalities under specified province(s) via commandline input.
 - Asks for an option to write results to a JSON file.
 - Run the script as follows if installed using `npm i ph-municipalities`:
@@ -431,10 +431,7 @@ const file = new ExcelFile({
 })
 
 // Load provinces from the custom config file
-const provinces = file
-  .settings
-  .data
-  .find(item => item.abbrev === 'INZ')?.provinces ?? []
+const provinces = file.listProvinces('Inazuma')
 
 // List the municipalities of defined provinces in the config file
 // Note: Province/municipality names should match with those in the 10-day Excel file

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -10,6 +10,7 @@ Dockerfile
 *.xlsx
 *.json
 *.zip
+*.tgz
 dist/
 
 # Ignore all JSON files except:

--- a/app/.eslintignore
+++ b/app/.eslintignore
@@ -4,6 +4,7 @@ node_modules/
 *.xlsx
 *.json
 *.zip
+*.tgz
 dist/
 
 # Ignore all JSON files except:

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 *.xlsx
 *.json
 *.zip
+*.tgz
 dist/
 
 # Ignore all JSON files except:

--- a/app/.npmignore
+++ b/app/.npmignore
@@ -6,12 +6,14 @@ dist/
 *.xlsx
 *.json
 *.zip
+*.txt
 
 .env.example
 .eslintrc.js
 .eslintrc_win.js
 .gitignore
 .npmignore
+.eslintignore
 
 # Ignore all JSON files except:
 !package.json
@@ -20,3 +22,10 @@ dist/
 
 # Ignore all Excel files except:
 !data/day1.xlsx
+
+# Exclude examples
+app/src/examples/
+
+# Docker
+Docker
+.dockerignore

--- a/app/.npmignore
+++ b/app/.npmignore
@@ -7,6 +7,7 @@ dist/
 *.json
 *.zip
 *.txt
+*.tgz
 
 .env.example
 .eslintrc.js
@@ -18,14 +19,14 @@ dist/
 # Ignore all JSON files except:
 !package.json
 !package-lock.json
-!app/config/regions.json
+!config/regions.json
 
 # Ignore all Excel files except:
 !data/day1.xlsx
 
 # Exclude examples
-app/src/examples/
+src/examples/
 
 # Docker
-Docker
+Dockerfile
 .dockerignore

--- a/app/.npmignore
+++ b/app/.npmignore
@@ -16,8 +16,7 @@ dist/
 # Ignore all JSON files except:
 !package.json
 !package-lock.json
-!data/regions.json
+!app/config/regions.json
 
 # Ignore all Excel files except:
-!data/regions.json
 !data/day1.xlsx

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ph-municipalities",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ph-municipalities",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ph-municipalities",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "List and write the `municipalities` of Philippines provinces or regions into JSON files",
   "main": "index.js",
   "engines": {

--- a/app/src/examples/05.js
+++ b/app/src/examples/05.js
@@ -13,10 +13,7 @@ const file = new ExcelFile({
 })
 
 // Load provinces from the custom config file
-const provinces = file
-  .settings
-  .data
-  .find(item => item.abbrev === 'INZ')?.provinces ?? []
+const provinces = file.listProvinces('Inazuma')
 
 // List the municipalities of defined provinces in the config file
 // Note: Province/municipality names should match with those in the 10-day Excel file


### PR DESCRIPTION
- Include the missing `regions.json` config file on npm publish, [#79] 
- Follow-up: exclude examples on npm publish
- Update custom config example