### PR TITLE
Feat/ciatph 68 - Test updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The following dependencies are used for this project. Feel free to use other dep
    - npm v8.5.0
 4. Excel file
    - ph-municipalities uses Excel files in the `/app/data` directory as data source.
-   - At minimum, the excel file should have a **column** that contains municipality and province names following the pattern `"municipalityName (provinceName)"`
+   - At minimum, the Excel file should have a **column** that contains municipality and province names following the pattern `"municipalityName (provinceName)"`
+   - (Optional) The Excel file should have a row on the same **column** as above containing the text `"Project Areas"` plus two (2) blank rows before rows containing municipality and province names to enable strict testing and validation of the number of parsed data rows
    - Checkout the excel file format on the `/app/data/day1.xlsx` sample file for more information
 5. (Optional) Download URL for a remote excel file.
    - See the `EXCEL_FILE_URL` variable on the [Installation](#installation) section.

--- a/app/__tests__/municipalities/createMunicipalityInstance.js
+++ b/app/__tests__/municipalities/createMunicipalityInstance.js
@@ -49,7 +49,8 @@ const createMunicipalityInstance = (excelFile) => {
 
     logger.log(
       `[INFO]: Parsed municipalities from config: ${config.countMunicipalities}\n` +
-      `loaded municipalities from Excel file: ${excel.countMunicipalities}\n`, {
+      `[INFO]: Parsed municipalities from Excel file: ${excel.countMunicipalities}\n` +
+      `[INFO]: Total data rows from Excel file: ${excelFile.data.length}, SheetJS (Excel) header rows count: ${excelFile.options.dataRowStart}\n`, {
         color: ColorLog.COLORS.TEXT.CYAN
       })
 

--- a/app/__tests__/municipalities/municipalitiesCount.js
+++ b/app/__tests__/municipalities/municipalitiesCount.js
@@ -70,7 +70,7 @@ describe('Municipalities total count match', () => {
     if (hasMissingInConfig || hasMissingInExcel) {
       logger.log(
         '[INFO]: If you believe these RED warning(s) are incorrect, feel free to reach out\n' +
-        'or extend and override the ExcelFile or ExcelFactory classes in your scripts.', {
+        'or you may extend and override the ExcelFile or ExcelFactory classes in your scripts.', {
           color: ColorLog.COLORS.TEXT.RED
         })
 

--- a/app/__tests__/provinces/createInstances.js
+++ b/app/__tests__/provinces/createInstances.js
@@ -37,10 +37,14 @@ const createInstances = (excelFile) => {
     // Action: remove these provinces from provinces count equality check
     const fromExcel = allExcelProvinces.filter(item => !allProvinces.includes(item))
 
-    // Log other information
-    logger.log(`[INFO]: Loaded ${excelFile.datalist.length} data rows`, {
-      color: ColorLog.COLORS.TEXT.GREEN
-    })
+    // Log other info
+    const dataSource = excelFile?.url ?? 'default local 10-Day Excel file'
+
+    let message = `[INFO]: Loaded ${excelFile.data.length} Excel rows\n`
+    message += `[INFO]: Parsed ${excelFile.datalist.length} data rows\n`
+    message += `[INFO]: from ${dataSource}\n`
+    message += `[INFO]: ${excelFile.metadata.forecastDate}`
+    logger.log(message, { color: ColorLog.COLORS.TEXT.GREEN })
 
     return {
       allExcelProvinces,

--- a/app/__tests__/provinces/updateInstances.js
+++ b/app/__tests__/provinces/updateInstances.js
@@ -51,7 +51,7 @@ const updateInstances = ({
       let msg = `[INFO]: Original provinces count are: ${allProvinces.length} (PAGASA seasonal config) vs. ${allExcelProvinces.length} (10-Day Excel file)\n`
       msg += '[INFO]: Removed incosistent provinces in the config and Excel file only during checking/testing (see yellow WARNINGs)\n'
       msg += `[INFO]: Modified provinces count are: ${uniqueProvinces.size} (PAGASA seasonal config) vs. ${uniqueExcelProvinces.size} (10-Day Excel file)\n\n`
-      msg += '[NOTE]: If these you believe these INFOs are incorrect, feel free to reach out or extend and override\n'
+      msg += '[NOTE]: If these you believe these INFOs are incorrect, feel free to reach out or you may extend and override\n'
       msg += 'the ExcelFile or ExcelFactory classes in your scripts to customize this behaviour and other settings.'
 
       logger.log(msg, {

--- a/app/__tests__/provinces/updateInstances.js
+++ b/app/__tests__/provinces/updateInstances.js
@@ -49,7 +49,7 @@ const updateInstances = ({
     // Provinces names do not match in 10-Day Excel file and the (PAGASA seasonal) config file
     if (fromExcel.length > 0 || fromConfig.length > 0) {
       let msg = `[INFO]: Original provinces count are: ${allProvinces.length} (PAGASA seasonal config) vs. ${allExcelProvinces.length} (10-Day Excel file)\n`
-      msg += '[INFO]: Removed incosistent provinces in the config and Excel file during check (see yellow WARNINGs)\n'
+      msg += '[INFO]: Removed incosistent provinces in the config and Excel file only during checking/testing (see yellow WARNINGs)\n'
       msg += `[INFO]: Modified provinces count are: ${uniqueProvinces.size} (PAGASA seasonal config) vs. ${uniqueExcelProvinces.size} (10-Day Excel file)\n\n`
       msg += '[NOTE]: If these you believe these INFOs are incorrect, feel free to reach out or extend and override\n'
       msg += 'the ExcelFile or ExcelFactory classes in your scripts to customize this behaviour and other settings.'

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ph-municipalities",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ph-municipalities",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ph-municipalities",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "List and write the `municipalities` of Philippines provinces or regions into JSON files",
   "main": "index.js",
   "engines": {

--- a/app/src/classes/excel/index.js
+++ b/app/src/classes/excel/index.js
@@ -237,7 +237,7 @@ class ExcelFile {
    * @returns {Bool} true | false
    */
   followsStringPattern (str) {
-    return /[a-zA-Z,.] *\([^)]*\) */.test(str)
+    return /[a-zA-Z,.] *\([^)]*\) *$/.test(str)
   }
 
   /**
@@ -325,6 +325,8 @@ class ExcelFile {
    * @returns {null} Returns null if "provinceName" is not found
    */
   getProvinceName (str) {
+    if (!str) return null
+
     const match = str.match(/\(([^)]+)\)/)
     return (match !== null)
       ? match[1]

--- a/app/src/lib/utils.js
+++ b/app/src/lib/utils.js
@@ -9,9 +9,29 @@ const isObject = (item) => {
     item.constructor === Object
 }
 
-const arrayToString = (array) => array.toString().split(',').join(', ')
+/**
+ * Converts an Array of strings (text) into a single comma-separated string
+ * @param {String[]} arrayOfText - Array containing String items
+ * @returns {String} Comma-separated text
+ */
+const arrayToString = (arrayOfText) => arrayOfText.toString().split(',').join(', ')
+
+/**
+ * Capitalizes the first letter of words in a text
+ * @param {String} text - String text
+ * @returns {String} Capitalized text
+ */
+const capitalizeText = (text) => {
+  if (typeof text !== 'string') return null
+
+  return text
+    .split(' ')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ')
+}
 
 module.exports = {
   isObject,
-  arrayToString
+  arrayToString,
+  capitalizeText
 }


### PR DESCRIPTION
- Included missing municipalities from PAGASA seasonal config when matching total parsed municipalities count with loaded Excel rows count, follow-up for [#68](https://github.com/ciatph/ph-municipalities/issues/68) 
- Display loaded Excel file information