### PR TITLE
feat: publish package to npm with provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,9 @@ jobs:
     name: Publish to NPM registry
     runs-on: ubuntu-latest
     needs: build-on-win
+    permissions:
+      contents: read
+      id-token: write
     env:
       IMAGE_URL: ${{ secrets.IMAGE_URL }}
     steps:
@@ -136,6 +139,6 @@ jobs:
           chmod u+x scripts/npm-publish.sh
           ./scripts/npm-publish.sh
           cd app
-          npm publish
+          npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## ph-municipalities
 
-The **ph-municipalities** NPM package provides **NPM scripts** that allow interactive querying of Philippine municipalities included in one or more provinces or from a whole region, with an option of writing them to JSON files from the command line through a CLI-like application and **classes** for parsing Excel file data sources.
+The **ph-municipalities** NPM package provides **NPM scripts** that allow interactive querying of Philippine municipalities included in one or more provinces or from a whole region, with an option of writing them to JSON files from the command line through a CLI-like application and **classes** for only parsing and listing municipality names and provinces from Excel file data sources.
 
 It uses a **PAGASA 10-day weather forecast Excel** file in `/app/data/day1.xlsx` (downloaded and stored as of this 20220808) from PAGASA's [10-Day Climate Forecast web page](https://www.pagasa.dost.gov.ph/climate/climate-prediction/10-day-climate-forecast) as the default data source.
 
@@ -40,9 +40,9 @@ Pre-compiled windows binaries are available for download in the latest [Releases
 <span id="class-documentation"></span>
 ## Class Documentation
 
-- Class and methods documentation are available at [https://ciatph.github.io/ph-municipalities](https://ciatph.github.io/ph-municipalities).
+- Class and methods documentation is available at [https://ciatph.github.io/ph-municipalities](https://ciatph.github.io/ph-municipalities).
 - Class source codes are available at the [ph-municipalities](https://github.com/ciatph/ph-municipalities) GitHub repository.
-- The documentation website's HTML files are available in the [`gh-pages`](https://github.com/ciatph/ph-municipalities/tree/gh-pages) branch of the GitHub repository.
+- The NPM package is available at https://www.npmjs.com/package/ph-municipalities
 - Refer to the [Building the Class Documentation](#building-the-class-documentation) section for more information about updating and building the class documentation.
 
 <span id="requirements"></span>
@@ -59,7 +59,7 @@ The following dependencies are used for this project. Feel free to use other dep
    - node v16.14.2
    - npm v8.5.0
 4. Excel file
-   - ph-municipalities uses Excel files in the `/app/data` directory as data source.
+   - ph-municipalities uses a PAGASA 10-Day Forecast Excel file in the `/app/data` directory as data source.
    - At minimum, the Excel file should have a **column** that contains municipality and province names following the pattern `"municipalityName (provinceName)"`
    - (Optional) The Excel file should have a row on the same **column** as above containing the text `"Project Areas"` plus two (2) blank rows before rows containing municipality and province names to enable strict testing and validation of the number of parsed data rows
    - Checkout the excel file format on the `/app/data/day1.xlsx` sample file for more information
@@ -81,11 +81,13 @@ The following dependencies are used for this project. Feel free to use other dep
 
 <br>
 
-ph-municipalities aims to provide a simple, organized, and flexible interface for viewing, querying, and listing Philippine provinces and municipalities using the [PAGASA 10-day weather forecast Excel files](https://www.pagasa.dost.gov.ph/climate/climate-prediction/10-day-climate-forecast) as the data source.
+ph-municipalities aims to provide a simple, organized, and flexible interface for viewing, querying, and listing Philippine provinces and municipalities using the [PAGASA 10-day weather forecast Excel files](https://www.pagasa.dost.gov.ph/climate/climate-prediction/10-day-climate-forecast) as the data source. It aims to enable easy extension of Philippine regions/provinces/municipalities listing for parsing the PAGASA 10-day weather forecast data.
 
 Its early stages were written as procedural functions within a _private backend project_ for extracting 10-day weather forecast data from the PAGASA 10-day weather forecast Excel files. When the private project started gaining complexity, a need to separate the logic and management for listing the Philippine province and municipalities per region rose. Creating an independent, public OpenSource version listing the provinces and municipalities per region was decided after experiencing drawbacks and difficulties testing using similar OpenSource libraries (some of which are [listed below](#similar-libraries)) for that project.
 
 > **_ph-municipalities aim to contribute to the OpenSource community by listing ONLY Philippine provinces and municipalities' names, using [PAGASA's 10-day weather forecast Excel files](https://www.pagasa.dost.gov.ph/climate/climate-prediction/10-day-climate-forecast), which are publicly accessible to everyone._**
+
+**ph-municipalities** is entirely public and open-source, and it has no linkage to private and proprietary source codes and resources.
 
 </details>
 
@@ -191,8 +193,12 @@ The PAGASA 10-day Excel files only contain province and municipality names linke
 
 This file contains region/province names mapping encoded manually with reference from the region and province names listed in the [PAGASA Seasonal Forecast website's](https://www.pagasa.dost.gov.ph/climate/climate-prediction/seasonal-forecast) Forecast Analysis Rainfall table.
 
+
+**ph-municipalities** expect similar region naming conventions from the **PAGASA Seasonal Forecast** and the **PAGASA 10-Day Forecast** since both are data products produced by PAGASA.
+
+
 > **NOTE:**<br>
-> The region/province mapping defined in this file may become outdated as time passes. ph-municipalities users are encouraged to [Use a Custom Configuration File](#using-a-custom-configuration-file), defining new region/province name mappings following the file's current format if they will notice region to province inconsistencies in the generated municipality lists.
+> The region/province mapping defined in this file may become outdated as time passes. ph-municipalities users are encouraged to [Use a Custom Configuration File](#using-a-custom-configuration-file), defining new region/province name mappings following the file's current format if they notice region-to-province inconsistencies in the generated municipality lists.
 
 </details>
 
@@ -211,7 +217,7 @@ NO. By default, ph-municipalities use an outdated PAGASA 10-day Excel file for i
 
 - Prompting to download an updated PAGASA 10-day Excel file using the [Interactive CLI Scripts](#interactive-cli-scripts)
 - Providing [class methods](https://ciatph.github.io/ph-municipalities/ExcelFile.html#download) for programmatically downloading and using a remote PAGASA 10-day Excel file
-- Allowing to override the default region - province list settings during class initialization (See [Class Usage - Using a Custom Configuration File](#using-a-custom-configuration-file))
+- Allowing to override the default region - province mapping settings during class initialization (See [Class Usage - Using a Custom Configuration File](#using-a-custom-configuration-file))
 
 > **NOTE:**<br>
 > Overall, the provinces and municipality list rely on the latest contents of a [PAGASA 10-day Excel file](https://www.pagasa.dost.gov.ph/climate/climate-prediction/10-day-climate-forecast) and manual configuration of region/province names mapping in the `/app/config/regions.json` file (See [Class Usage - Using a Custom Configuration File](#using-a-custom-configuration-file)). It is not yet known and tested if these are in sync with the latest regions, provinces, and municipalities in the more standard and canon [Philippine Standard Geographic Code (PSGC)](https://psa.gov.ph/classification/psgc) data.

--- a/README.md
+++ b/README.md
@@ -707,11 +707,15 @@ main()
 <span id="using-a-custom-configuration-file"></span>
 ### Using a Custom Configuration File
 
-The **ph-municipalities** `ExcelFile` and `ExcelFactory` classes use a default configuration file to define their regions and provinces in the `/app/config/regions.json` file. The regions and provinces data in this file syncs with the PAGASA Seasonal and 10-Day Weather Forecast Excel files provinces and municipalities naming convention, encoded by hand as of August 24, 2024.
+The **ph-municipalities** `ExcelFile` and `ExcelFactory` classes use a default configuration file to define their regions and provinces in the `/app/config/regions.json` file. The data in this file syncs with the PAGASA Seasonal and 10-Day Weather Forecast Excel files provinces and municipalities naming convention, encoded by hand as of August 24, 2024.
 
 Follow the codes to define a custom regions config file, following the format of the `/app/config/regions.json` file to customize region definitions.
 
 > _**Note:** The custom config file's province/municipality names should match those in the 10-day Excel file._
+
+#### Availability
+
+This method is available from ph-municipalities from v1.3.3 and higher.
 
 <details>
 <summary>

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -4,6 +4,7 @@ docs/
 diagrams/
 README.md
 README.tmp
+LICENSE
 .env
 .vscode
 *.xlsx

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ph-municipalities",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ph-municipalities",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "dotenv": "^16.0.1",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "ph-municipalities",
       "version": "1.4.1",
-      "license": "ISC",
+      "license": "Apache-2.0",
       "dependencies": {
         "dotenv": "^16.0.1",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.18.10/xlsx-0.18.10.tgz",
@@ -24,8 +24,8 @@
         "pkg": "^5.8.0"
       },
       "engines": {
-        "node": "16.14.2",
-        "npm": "8.5.0"
+        "node": ">=16.14.2",
+        "npm": ">=8.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ph-municipalities",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "List and write the `municipalities` of Philippines provinces or regions into JSON files",
   "main": "index.js",
   "engines": {

--- a/app/package.json
+++ b/app/package.json
@@ -4,8 +4,8 @@
   "description": "List and write the `municipalities` of Philippines provinces or regions into JSON files",
   "main": "index.js",
   "engines": {
-    "node": "16.14.2",
-    "npm": "8.5.0"
+    "node": ">=16.14.2",
+    "npm": ">=8.5.0"
   },
   "scripts": {
     "start": "npm run list:region",
@@ -29,8 +29,20 @@
     "type": "git",
     "url": "git+https://github.com/ciatph/ph-municipalities.git"
   },
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "philippines",
+    "philippines json",
+    "philippines regions",
+    "philippines provinces",
+    "philippines municipalities",
+    "pagasa",
+    "pagasa 10-day forecast",
+    "pagasa-parser",
+    "xlsx",
+    "sheetjs"
+  ],
+  "author": "ciatph",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ciatph/ph-municipalities/issues"
   },

--- a/app/src/classes/excel/index.js
+++ b/app/src/classes/excel/index.js
@@ -513,7 +513,6 @@ class ExcelFile {
 
   /**
    * Lists the province names of a region defined in the settings (PAGASA seasonal config) file or from the parsed Excel file
-   * @param {string} region - Region name that matches with the `/app/config/regions.json` file's `data[N].name`
    * @param {boolean} fromExcel - Flag to return the province names from the parsed 10-day Excel file. Defaults to `false`.
    *    - Note: Province names from a "remote" Excel file may change without notice.
    *    - It may differ from the contents of the "default" settings (PAGASA seasonal config) file.

--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -2,3 +2,6 @@
 
 # Use image file from remote URL source since NPM does not allow displaying images by relative path
 sed "s|/docs/diagrams/ph-municipalities-arch-90.png|${IMAGE_URL}|g" README.md > app/README.md
+
+# Copy license file
+cp LICENSE app/


### PR DESCRIPTION
- Feat: publish to the npm registry with provenance, [#125](https://github.com/ciatph/ph-municipalities/issues/125)
- Chore: update package.json: 
   - Set engines (node: >=16.14.2, npm: >+8.5.0)
   - Add keywords
   - Update license type
- Docs: README content updates
- Docs: note availability of [custom config settings](https://github.com/ciatph/ph-municipalities?tab=readme-ov-file#using-a-custom-configuration-file) from v1.3.3+