### PR TITLE
fix: publish npm package with provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
     name: Publish to NPM registry
     # if: github.event.release.target_commitish == 'master'
     runs-on: ubuntu-latest
-    needs: build-on-win
+    # needs: build-on-win
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ name: Package Windows Binaries
 on:
   release:
     types: [published]
-  push:
-    branches-ignore:
-      - 'master'
 
 jobs:
   test-app:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,9 +121,9 @@ jobs:
 
   publish-npm:
     name: Publish to NPM registry
-    # if: github.event.release.target_commitish == 'master'
+    if: github.event.release.target_commitish == 'master'
     runs-on: ubuntu-latest
-    # needs: build-on-win
+    needs: build-on-win
     permissions:
       contents: read
       id-token: write
@@ -135,10 +135,11 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - name: Use NodeJS v16.14.2
+      # Fix: use Node v20 (latest than v16) when publishing with provenance
+      - name: Use NodeJS v20.15.0
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
+          node-version: 20.15.0
           registry-url: https://registry.npmjs.org/
 
       - name: Publish package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,14 @@ name: Package Windows Binaries
 on:
   release:
     types: [published]
+  push:
+    branches-ignore:
+      - 'master'
 
 jobs:
   test-app:
     name: Lint and Test App
+    if: github.event.release.target_commitish == 'master'
     runs-on: ubuntu-latest
     env:
       EXCEL_FILE_URL: ${{ secrets.EXCEL_FILE_URL }}
@@ -39,6 +43,7 @@ jobs:
 
   build-on-win:
     name: Build and Package App
+    if: github.event.release.target_commitish == 'master'
     runs-on: windows-latest
     needs: test-app
     steps:
@@ -87,6 +92,7 @@ jobs:
 
   release:
     name: Release Built Binary
+    if: github.event.release.target_commitish == 'master'
     needs: build-on-win
     runs-on: ubuntu-latest
     steps:
@@ -115,6 +121,7 @@ jobs:
 
   publish-npm:
     name: Publish to NPM registry
+    # if: github.event.release.target_commitish == 'master'
     runs-on: ubuntu-latest
     needs: build-on-win
     permissions:
@@ -129,9 +136,9 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Use NodeJS v16.14.2
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.14.2
           registry-url: https://registry.npmjs.org/
 
       - name: Publish package


### PR DESCRIPTION
- Fix: use Node v20 when publishing with provenance, [#125](https://github.com/ciatph/ph-municipalities/issues/125)
- Chore: run the Release jobs only from tags from the master branch 