### PR TITLE
fix: run scheduled tests from latest tag

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -18,8 +18,14 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.release.tag_name }}
+
+      - name: Fetch and check out latest tag
+        run: |
+          git fetch --tags
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "Checking out latest tag: $LATEST_TAG"
+          git checkout $LATEST_TAG
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
 
       - name: Use NodeJS v16.14.2
         uses: actions/setup-node@v3


### PR DESCRIPTION
- Fix: checkout the latest release tag for testing
- Follow-up fix for item [#134](https://github.com/ciatph/ph-municipalities/issues/134)