### PR TITLE
fix: upgrade xlsx version v0.20.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Package Windows Binaries
+name: Deploy Release
 
 # This workflow will trigger on any tag/release created on *any* branch
 # Make sure to create tags/releases only from the "master" branch for consistency

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Click to expand the table of contents
 ## Installation
 
 1. Clone this repository.<br>
-`git clone https://github.com/ciatph/municipalities-by-province.git`
+`git clone https://github.com/ciatph/ph-municipalities.git`
 
 2. Install dependencies.<br>
    ```bash

--- a/README.md
+++ b/README.md
@@ -59,9 +59,12 @@ The following dependencies are used for this project. Feel free to use other dep
 
 1. Windows 10 OS
 2. nvm for Windows v1.1.9
-3. NodeJS, installed using nvm
-   - node v16.14.2
-   - npm v8.5.0
+3. NodeJS LTS v16 or higher, installed using nvm
+   ```
+   Recommended:
+   node v16.14.2
+   npm v8.5.0
+   ```
 4. Excel file
    - ph-municipalities uses a PAGASA 10-Day Forecast Excel file in the `/app/data` directory as data source.
    - At minimum, the Excel file should have a **column** that contains municipality and province names following the pattern `"municipalityName (provinceName)"`

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,5 +1,5 @@
 # BASE PROFILE
-FROM node:20.15.0-alpine as base
+FROM node:20.15.0-alpine AS base
 RUN mkdir -p /opt/app
 WORKDIR /opt/app
 RUN adduser -S app
@@ -7,7 +7,7 @@ RUN chown -R app /opt/app
 COPY package*.json ./
 
 # DEVELOPMENT PROFILE
-FROM base as development
+FROM base AS development
 RUN npm install && npm cache clean --force
 COPY . ./
 USER app

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.4.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "dotenv": "^16.0.1",
+        "dotenv": "^16.4.7",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
-        "zod": "^3.23.8"
+        "zod": "^3.24.1"
       },
       "devDependencies": {
-        "@vercel/ncc": "^0.34.0",
+        "@vercel/ncc": "^0.38.3",
         "eslint": "^8.21.0",
-        "eslint-config-standard": "^17.0.0",
+        "eslint-config-standard": "^17.1.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.0.0",
@@ -1506,9 +1506,9 @@
       "dev": true
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
-      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.3.tgz",
+      "integrity": "sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -2300,11 +2300,14 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2490,9 +2493,9 @@
       }
     },
     "node_modules/eslint-config-standard": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
-      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz",
+      "integrity": "sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==",
       "dev": true,
       "funding": [
         {
@@ -2508,10 +2511,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "eslint": "^8.0.1",
         "eslint-plugin-import": "^2.25.2",
-        "eslint-plugin-n": "^15.0.0",
+        "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
         "eslint-plugin-promise": "^6.0.0"
       }
     },
@@ -6324,9 +6330,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -7498,9 +7504,9 @@
       "dev": true
     },
     "@vercel/ncc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
-      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.3.tgz",
+      "integrity": "sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==",
       "dev": true
     },
     "acorn": {
@@ -8052,9 +8058,9 @@
       }
     },
     "dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="
     },
     "electron-to-chromium": {
       "version": "1.5.13",
@@ -8203,9 +8209,9 @@
       }
     },
     "eslint-config-standard": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
-      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz",
+      "integrity": "sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==",
       "dev": true,
       "requires": {}
     },
@@ -10991,9 +10997,9 @@
       "dev": true
     },
     "zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A=="
     }
   }
 }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ph-municipalities",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ph-municipalities",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "dotenv": "^16.4.7",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "dotenv": "^16.0.1",
-        "xlsx": "https://cdn.sheetjs.com/xlsx-0.18.10/xlsx-0.18.10.tgz",
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -24,8 +24,7 @@
         "pkg": "^5.8.0"
       },
       "engines": {
-        "node": ">=16.14.2",
-        "npm": ">=8.5.0"
+        "node": ">=16"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6259,9 +6258,9 @@
       }
     },
     "node_modules/xlsx": {
-      "version": "0.18.10",
-      "resolved": "https://cdn.sheetjs.com/xlsx-0.18.10/xlsx-0.18.10.tgz",
-      "integrity": "sha512-mY2CU0mXUT0J98ew3DfTAn9fPVjDi22LemGU0SJ6wk6kELMlAKQFNPdyBVDa+012rpCSexBYyTobv4f4Puf6qg==",
+      "version": "0.20.3",
+      "resolved": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+      "integrity": "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==",
       "license": "Apache-2.0",
       "bin": {
         "xlsx": "bin/xlsx.njs"
@@ -10949,8 +10948,8 @@
       }
     },
     "xlsx": {
-      "version": "https://cdn.sheetjs.com/xlsx-0.18.10/xlsx-0.18.10.tgz",
-      "integrity": "sha512-mY2CU0mXUT0J98ew3DfTAn9fPVjDi22LemGU0SJ6wk6kELMlAKQFNPdyBVDa+012rpCSexBYyTobv4f4Puf6qg=="
+      "version": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+      "integrity": "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ph-municipalities",
   "version": "1.4.3",
-  "description": "List and write the `municipalities` of Philippines provinces or regions into JSON files",
+  "description": "Lists and writes Philippine municipalities by province or region into JSON files using PAGASA 10-Day weather forecast Excel files as a data source",
   "main": "index.js",
   "engines": {
     "node": ">=16"

--- a/app/package.json
+++ b/app/package.json
@@ -47,9 +47,9 @@
   },
   "homepage": "https://github.com/ciatph/ph-municipalities#readme",
   "devDependencies": {
-    "@vercel/ncc": "^0.34.0",
+    "@vercel/ncc": "^0.38.3",
     "eslint": "^8.21.0",
-    "eslint-config-standard": "^17.0.0",
+    "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.0",
@@ -57,9 +57,9 @@
     "pkg": "^5.8.0"
   },
   "dependencies": {
-    "dotenv": "^16.0.1",
+    "dotenv": "^16.4.7",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
-    "zod": "^3.23.8"
+    "zod": "^3.24.1"
   },
   "pkg": {
     "assets": [

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ph-municipalities",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Lists and writes Philippine municipalities by province or region into JSON files using PAGASA 10-Day weather forecast Excel files as a data source",
   "main": "index.js",
   "engines": {

--- a/app/package.json
+++ b/app/package.json
@@ -4,8 +4,7 @@
   "description": "List and write the `municipalities` of Philippines provinces or regions into JSON files",
   "main": "index.js",
   "engines": {
-    "node": ">=16.14.2",
-    "npm": ">=8.5.0"
+    "node": ">=16"
   },
   "scripts": {
     "start": "npm run list:region",
@@ -59,7 +58,7 @@
   },
   "dependencies": {
     "dotenv": "^16.0.1",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.18.10/xlsx-0.18.10.tgz",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^3.23.8"
   },
   "pkg": {


### PR DESCRIPTION
### Updates

- Chore: upgrade xlsx dependency to v0.20.3, [#138](https://github.com/ciatph/ph-municipalities/issues/138)
- Chore: Upgrade other dependencies (see table)
- Chore: update package.json - set `"engines": ">=16"`

### Other Dependency Updates

| Package | Old | New |
| --- | :---: | :---: |
| dotenv | 16.0.1 | 16.4.7 |
| zod | 3.23.8 | 3.24.1 |
| @vercel/ncc | 0.34.0 | 0.38.3 |
| eslint-config-standard | 17.0.0 | 17.1.0 |