### PR TITLE
fix: use the latest data rows start indicator text

### DIFF
--- a/app/__tests__/municipalities/municipalitiesCount.js
+++ b/app/__tests__/municipalities/municipalitiesCount.js
@@ -73,8 +73,9 @@ describe('Municipalities total count match', () => {
 
       let passMsg = '[20240826]: Allow the test to succeed here since there is little information about updated\n'
       passMsg += 'PAGASA seasonal & 10-day province/municipalities naming conventions for the other regions, and they\n'
-      passMsg += 'may change anytime without prior notice. Take note of the INFOS/WARNINGS and\n'
-      passMsg += 'extend/override the class methods on custom scripts to accommodate custom settings as necessary'
+      passMsg += 'may change anytime without prior notice. Take note of the INFOS/WARNINGS and to accommodate CUSTOM SETTINGS as necessary:\n'
+      passMsg += '- Extend/override the class methods on custom scripts or\n'
+      passMsg += '- Eass custom (updated) regions.json config to the class constructors'
       expect(logger.log(passMsg, { color: ColorLog.COLORS.TEXT.YELLOW })).toBe(undefined)
     } else {
       logger.log('[MUNICIPALITIES]: Municipalities counts match in config and Excel', {

--- a/app/__tests__/provinces/updateInstances.js
+++ b/app/__tests__/provinces/updateInstances.js
@@ -52,7 +52,8 @@ const updateInstances = ({
       msg += '[INFO]: Removed incosistent provinces in the config and Excel file only during checking/testing (see yellow WARNINGs)\n'
       msg += `[INFO]: Modified provinces count are: ${uniqueProvinces.size} (PAGASA seasonal config) vs. ${uniqueExcelProvinces.size} (10-Day Excel file)\n\n`
       msg += '[NOTE]: If you believe these INFOs are incorrect, feel free to reach out or you may extend and override\n'
-      msg += 'the ExcelFile or ExcelFactory classes in your scripts to customize this behaviour and other settings.'
+      msg += 'the ExcelFile or ExcelFactory class methods or pass them custom regions.json config in your scripts to\n'
+      msg += 'customize this behaviour and other logic.'
 
       logger.log(msg, {
         color: ColorLog.COLORS.TEXT.CYAN

--- a/app/src/classes/excel/index.js
+++ b/app/src/classes/excel/index.js
@@ -229,7 +229,7 @@ class ExcelFile {
         } else {
           // Find the SheetJS array index of rows containing data
           // Note: this relies on the structure of the default Excel file in /app/data/day1.xlsx or similar
-          if (row[this.#options.SHEETJS_COL] === 'Project Areas') {
+          if (row[this.#options.SHEETJS_COL] === 'Municipalities') {
             const OFFSET_FROM_FLAG = 2
             this.#options.dataRowStart = index + OFFSET_FROM_FLAG
           }


### PR DESCRIPTION
- Fix: use the `"Municipalities"` text as indicator of the beginning of the Excel data rows, [#144](https://github.com/ciatph/ph-municipalities/issues/144)
- Chore: add notes about extending the `ExcelFile` / `ExcelFactory` classes and passing custom `regions.json` config in their constructors in the CLI logs 