### PR TITLE
fix: update actions/cache to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           node-version: 16.14.2
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('app/package-lock.json') }}


### PR DESCRIPTION
- Fix: upgrade the GH Actions actions/cache to v4 since v2 is now deprecated
- Fixes the failing build at [Deploy Release](https://github.com/ciatph/ph-municipalities/actions/runs/16405201039)